### PR TITLE
Changelog

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -37,5 +37,6 @@ next-env.d.ts
 /generated
 
 content/wiki
+content/changelog
 
 # pnpm

--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -9,6 +9,16 @@ async function markdownToHtml(md: string): Promise<string> {
   return String(file);
 }
 
+// determines which version number was incremented in a release
+function bumpLevel(curr: string, prev?: string): 1 | 2 | 3 | 4 {
+  if (!prev) return 4;
+  const toNums = (t: string) =>
+    t.replace(/^v/i, "").split(".").map((n) => parseInt(n, 10) || 0);
+  const c = toNums(curr), p = toNums(prev);
+  for (let i = 0; i < 4; i++) if ((c[i] ?? 0) !== (p[i] ?? 0)) return (i + 1) as 1|2|3|4;
+  return 4;
+}
+
 export const dynamic = "force-dynamic";
 
 type SearchProps = {
@@ -55,6 +65,21 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
           const date = new Date(rel.published_at);
 
           const globalIndex = (page - 1) * perPage + idx;
+          const prevTag = releases[idx + 1]?.tag_name;
+          const level = bumpLevel(rel.tag_name, prevTag);
+
+          const sizeClass =
+            level === 1 ? "text-4xl" :
+            level === 2 ? "text-3xl" :
+            level === 3 ? "text-xl"  :
+                          "text-base";
+
+          const weightClass =
+            level === 1 ? "font-black"     :
+            level === 2 ? "font-extrabold" :
+            level === 3 ? "font-bold"      :
+                          "font-medium";
+
           const latestBadge =
             globalIndex === 0 ? (
               <span className="ml-2 text-xs px-2 py-0.5 rounded bg-primary-100 text-primary-700">
@@ -68,7 +93,7 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
                 <summary className="cursor-pointer list-none p-4 hover:bg-default-100 rounded-t-md">
                   <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                     <div className="flex items-center gap-2">
-                      <span className="font-semibold">{rel.name}</span>
+                      <span className={`${sizeClass} ${weightClass}`}>{rel.name}</span>
                       <span className="text-default-500">({rel.tag_name})</span>
                       {latestBadge}
                     </div>

--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -1,8 +1,24 @@
 import { getPaginatedReleases } from "@/lib/changelog";
+import { Metadata } from "next";
 import Link from "next/link";
 import { remark } from "remark";
 import remarkGfm from "remark-gfm";
 import remarkHtml from "remark-html";
+
+export const metadata: Metadata = {
+  title: "Changelog",
+  description: "Look at the latest features added to CORE Game.",
+  openGraph: {
+    title: "Changelog",
+    description: "Look at the latest features added to CORE Game.",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Changelog",
+    description: "Look at the latest features added to CORE Game.",
+  },
+};
 
 async function markdownToHtml(md: string): Promise<string> {
   const file = await remark().use(remarkGfm).use(remarkHtml).process(md || "");

--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -21,7 +21,10 @@ export const metadata: Metadata = {
 };
 
 async function markdownToHtml(md: string): Promise<string> {
-  const file = await remark().use(remarkGfm).use(remarkHtml).process(md || "");
+  const file = await remark()
+    .use(remarkGfm)
+    .use(remarkHtml)
+    .process(md || "");
   return String(file);
 }
 
@@ -29,9 +32,14 @@ async function markdownToHtml(md: string): Promise<string> {
 function bumpLevel(curr: string, prev?: string): 1 | 2 | 3 | 4 {
   if (!prev) return 4;
   const toNums = (t: string) =>
-    t.replace(/^v/i, "").split(".").map((n) => parseInt(n, 10) || 0);
-  const c = toNums(curr), p = toNums(prev);
-  for (let i = 0; i < 4; i++) if ((c[i] ?? 0) !== (p[i] ?? 0)) return (i + 1) as 1|2|3|4;
+    t
+      .replace(/^v/i, "")
+      .split(".")
+      .map((n) => parseInt(n, 10) || 0);
+  const c = toNums(curr),
+    p = toNums(prev);
+  for (let i = 0; i < 4; i++)
+    if ((c[i] ?? 0) !== (p[i] ?? 0)) return (i + 1) as 1 | 2 | 3 | 4;
   return 4;
 }
 
@@ -59,8 +67,8 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
 
   return (
     <div className="py-10">
-      <header className="mb-8">
-        <h1 className="text-4xl font-bold">Changelog</h1>
+      <header className="mb-4">
+        <h1 className="text-4xl font-bold pb-2">Changelog</h1>
         <p className="text-default-500">
           All changes from{" "}
           <a
@@ -85,16 +93,22 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
           const level = bumpLevel(rel.tag_name, prevTag);
 
           const sizeClass =
-            level === 1 ? "text-4xl" :
-            level === 2 ? "text-3xl" :
-            level === 3 ? "text-xl"  :
-                          "text-base";
+            level === 1
+              ? "text-4xl"
+              : level === 2
+                ? "text-3xl"
+                : level === 3
+                  ? "text-xl"
+                  : "text-base";
 
           const weightClass =
-            level === 1 ? "font-black"     :
-            level === 2 ? "font-extrabold" :
-            level === 3 ? "font-bold"      :
-                          "font-medium";
+            level === 1
+              ? "font-black"
+              : level === 2
+                ? "font-extrabold"
+                : level === 3
+                  ? "font-bold"
+                  : "font-medium";
 
           const latestBadge =
             globalIndex === 0 ? (
@@ -109,7 +123,9 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
                 <summary className="cursor-pointer list-none p-4 hover:bg-default-100 rounded-t-md">
                   <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                     <div className="flex items-center gap-2">
-                      <span className={`${sizeClass} ${weightClass}`}>{rel.name}</span>
+                      <span className={`${sizeClass} ${weightClass}`}>
+                        {rel.name}
+                      </span>
                       <span className="text-default-500">({rel.tag_name})</span>
                       {latestBadge}
                     </div>
@@ -119,7 +135,7 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
                   </div>
                 </summary>
 
-                <div className="px-4 pb-4">
+                <div className="px-4 pb-4 pt-2">
                   {html.trim() ? (
                     <article
                       className="prose dark:prose-invert max-w-none"

--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -9,13 +9,13 @@ async function markdownToHtml(md: string): Promise<string> {
   return String(file);
 }
 
-export const dynamic = "force-static";
+export const dynamic = "force-dynamic";
 
 type SearchProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
-const PAGE_SIZE = 21;
+const PAGE_SIZE = 42;
 
 export default async function ChangelogPage({ searchParams }: SearchProps) {
   const sp = (await searchParams) || {};

--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -27,7 +27,6 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
     PAGE_SIZE,
   );
 
-  // Pre-render Markdown bodies to HTML at build-time
   const renderedBodies = await Promise.all(
     releases.map((r) => markdownToHtml(r.body)),
   );
@@ -54,10 +53,12 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
         {releases.map((rel, idx) => {
           const html = renderedBodies[idx];
           const date = new Date(rel.published_at);
-          const badge =
-            rel.prerelease ? (
-              <span className="ml-2 text-xs px-2 py-0.5 rounded bg-warning-100 text-warning-700">
-                prerelease
+
+          const globalIndex = (page - 1) * perPage + idx;
+          const latestBadge =
+            globalIndex === 0 ? (
+              <span className="ml-2 text-xs px-2 py-0.5 rounded bg-primary-100 text-primary-700">
+                latest
               </span>
             ) : null;
 
@@ -69,7 +70,7 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
                     <div className="flex items-center gap-2">
                       <span className="font-semibold">{rel.name}</span>
                       <span className="text-default-500">({rel.tag_name})</span>
-                      {badge}
+                      {latestBadge}
                     </div>
                     <div className="text-sm text-default-500">
                       {date.toLocaleDateString()}

--- a/frontend/app/changelog/page.tsx
+++ b/frontend/app/changelog/page.tsx
@@ -64,7 +64,7 @@ export default async function ChangelogPage({ searchParams }: SearchProps) {
 
           return (
             <li key={rel.id} className="border border-default-200 rounded-md">
-              <details>
+              <details {...(globalIndex === 0 ? { open: true } : {})}>
                 <summary className="cursor-pointer list-none p-4 hover:bg-default-100 rounded-t-md">
                   <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                     <div className="flex items-center gap-2">

--- a/frontend/layouts/basic-navbar.tsx
+++ b/frontend/layouts/basic-navbar.tsx
@@ -149,6 +149,18 @@ const BasicNavbar = React.forwardRef<
         <NavbarItem>
           <Link
             className={cn("text-default-500", {
+              "font-bold text-default-foreground": isActive("/changelog"),
+            })}
+            href="/changelog"
+            onPointerDown={() => setClickedItem("/changelog")}
+            onClick={() => setClickedItem("/changelog")}
+          >
+            Changelog
+          </Link>
+        </NavbarItem>
+        <NavbarItem>
+          <Link
+            className={cn("text-default-500", {
               "font-bold text-default-foreground": isActive("/about"),
             })}
             href="/about"

--- a/frontend/lib/changelog.ts
+++ b/frontend/lib/changelog.ts
@@ -1,0 +1,41 @@
+import fs from "fs";
+import path from "path";
+
+export type Release = {
+  id: number;
+  tag_name: string;
+  name: string;
+  body: string;
+  html_url: string;
+  published_at: string; // ISO
+  prerelease: boolean;
+  author: string | null;
+};
+
+const DATA_PATH = path.join(process.cwd(), "content/changelog/releases.json");
+
+export function getAllReleases(): Release[] {
+  if (!fs.existsSync(DATA_PATH)) return [];
+  const raw = fs.readFileSync(DATA_PATH, "utf8");
+  const arr: Release[] = JSON.parse(raw);
+  // defensive sort (newest first)
+  return arr.sort(
+    (a, b) => new Date(b.published_at).getTime() - new Date(a.published_at).getTime(),
+  );
+}
+
+export function getPaginatedReleases(page: number, perPage: number) {
+  const releases = getAllReleases();
+  const total = releases.length;
+  const totalPages = Math.max(1, Math.ceil(total / perPage));
+  const safePage = Math.min(Math.max(1, page), totalPages);
+  const start = (safePage - 1) * perPage;
+  const end = start + perPage;
+  return {
+    releases: releases.slice(start, end),
+    total,
+    totalPages,
+    page: safePage,
+    perPage,
+  };
+}

--- a/frontend/lib/changelog.ts
+++ b/frontend/lib/changelog.ts
@@ -8,7 +8,6 @@ export type Release = {
   body: string;
   html_url: string;
   published_at: string; // ISO
-  prerelease: boolean;
   author: string | null;
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "prebuild": "node scripts/clone-wiki-branches.js",
+    "prebuild": "node scripts/clone-wiki-branches.js && node scripts/fetch-releases.js",
     "clone:wiki": "node scripts/clone-wiki-branches.js",
     "dev": "next dev --turbo",
     "build": "next build",

--- a/frontend/scripts/fetch-releases.js
+++ b/frontend/scripts/fetch-releases.js
@@ -1,0 +1,74 @@
+const fs = require("fs");
+const path = require("path");
+const axios = require("axios");
+
+const PER_PAGE = 100;
+const OUT_DIR = path.join(__dirname, "../content/changelog");
+const OUT_FILE = path.join(OUT_DIR, "releases.json");
+
+async function fetchAllReleases() {
+  const base = `https://api.github.com/repos/42core-team/monorepo/releases`;
+  let page = 1;
+  const all = [];
+
+  // 60 unauthenticated requests/hour. After 6000 releases, this code will start failing. Should be fine for the next few decades...
+  while (true) {
+    const url = `${base}?per_page=${PER_PAGE}&page=${page}`;
+    const { data } = await axios.get(url, {
+      headers: {
+        "User-Agent": "coregame-build",
+        Accept: "application/vnd.github+json",
+      },
+      validateStatus: (s) => s >= 200 && s < 500,
+    });
+
+    if (!Array.isArray(data)) {
+      throw new Error(
+        `GitHub API error (status likely 4xx/5xx). Response: ${JSON.stringify(
+          data,
+        ).slice(0, 200)}...`,
+      );
+    }
+
+    if (data.length === 0) break;
+
+    for (const r of data) {
+      if (r.draft || r.prerelease) continue;
+      all.push({
+        id: r.id,
+        tag_name: r.tag_name,
+        name: r.name || r.tag_name,
+        body: r.body || "",
+        html_url: r.html_url,
+        published_at: r.published_at || r.created_at,
+        author: r.author?.login || null,
+      });
+    }
+
+    if (data.length < PER_PAGE) break;
+    page += 1;
+  }
+
+  all.sort(
+    (a, b) => new Date(b.published_at).getTime() - new Date(a.published_at).getTime(),
+  );
+
+  return all;
+}
+
+(async () => {
+  try {
+    const releases = await fetchAllReleases();
+    fs.mkdirSync(OUT_DIR, { recursive: true });
+    fs.writeFileSync(OUT_FILE, JSON.stringify(releases, null, 2), "utf8");
+    console.log(
+      `Saved ${releases.length} release(s) to ${path.relative(
+        process.cwd(),
+        OUT_FILE,
+      )}`,
+    );
+  } catch (err) {
+    console.error("Failed to fetch releases:", err?.message || err);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
Added a working changelog tab. GitHub releases from the monorepo get pulled from when the frontend is built & saved into a big json file, which is then read from live. Supports pagination. Currently does not use pagination, which shouldn't be an issue until we hit over 6000 releases, then the GitHub API will rate limit us. We should be fine for the foreseeable future. I think it works well and looks good, I'll go back and freshen up the previous releases, and then we can put some nicer info into the future releases.

<img width="1286" height="911" alt="Screenshot 2025-09-16 at 17 21 36" src="https://github.com/user-attachments/assets/046ebd6e-65aa-401b-b4f8-b6444b40de44" />

Note in the screenshot I renamed Wiki to Documentation because I thought it sounded more professional, but when trying to change it I decided it was too much work. It isn't in the final PR. Maybe at a later point.