### PR TITLE
default-expand wiki subfolders

### DIFF
--- a/frontend/components/wiki/WikiNavigation.tsx
+++ b/frontend/components/wiki/WikiNavigation.tsx
@@ -217,12 +217,23 @@ export function WikiNavigation({
       );
     }
 
+    const collectAllPaths = (items: WikiNavItem[]): string[] => {
+      return items.flatMap((item) => {
+        const path = item.slug.join("/");
+        if (item.children && item.children.length > 0) {
+          return [path, ...collectAllPaths(item.children)];
+        }
+        return [];
+      });
+    };
+    const allPaths = collectAllPaths(items);
+
     if (item.children && item.children.length > 0) {
       return (
         <Accordion
           key={uniqueKey}
           variant="light"
-          defaultExpandedKeys={isParentActive ? [itemPath] : []}
+          defaultExpandedKeys={allPaths}
         >
           <AccordionItem
             key={itemPath}


### PR DESCRIPTION
heyy so i started using subfolders in the wiki, it's cleaner now. But I'm worried people will be too dumb to find the important Core Game Lib Pages now that they're in a subfolder, so this PR expands all the wiki subfolders by default. Seeing as we only have one subfolder, I think that's perfectly fine and won't get messy unless we start adding many many subfolders which I think is unlikely.

Before:

<img width="266" height="629" alt="Screenshot 2025-10-01 at 12 43 26" src="https://github.com/user-attachments/assets/d1352e95-2473-4332-9fd9-176ec31c94a6" />

After:

<img width="261" height="908" alt="Screenshot 2025-10-01 at 12 43 39" src="https://github.com/user-attachments/assets/f9192ab3-d945-4587-adda-791eba14c177" />
